### PR TITLE
Loosen the version requirement on the redis gem.

### DIFF
--- a/redis-mutex.gemspec
+++ b/redis-mutex.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", "~> 3.1.0"
+  spec.add_dependency "redis", "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.7.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Sidekiq requires 3.2, no reason we can't support that too!